### PR TITLE
Auth Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 server/var/db/twitter-clone.db
+.DS_Store

--- a/TwitterClone/Targets/Auth/Sources/TwitterCloneAuth.swift
+++ b/TwitterClone/Targets/Auth/Sources/TwitterCloneAuth.swift
@@ -90,22 +90,23 @@ public final class TwitterCloneAuth: TwitterCloneClient, ObservableObject {
     public var authUser: AuthUser?
 
     private var storedAuthUser: AuthUser? {
-        os_log("Load credentials from keychain")
         guard
             let feedToken = keychainHelper.string(for: .feedToken),
             let chatToken = keychainHelper.string(for: .chatToken),
             let username = keychainHelper.string(for: .username),
             let userId = keychainHelper.string(for: .userId)
         else {
+            os_log("No credentials found in keychain")
             return nil
         }
 
+        os_log("Load credentials from keychain")
         return AuthUser(feedToken: feedToken, chatToken: chatToken, username: username, userId: userId)
     }
 
     private let keychainHelper = KeyChainHelper.shared
 
-    public override init(baseUrl baseUrlString: String) throws {
+    override public init(baseUrl baseUrlString: String) throws {
         os_log("Init auth")
         try super.init(baseUrl: baseUrlString)
         authUser = storedAuthUser

--- a/TwitterClone/Targets/NetworkKit/Sources/TwitterCloneClient.swift
+++ b/TwitterClone/Targets/NetworkKit/Sources/TwitterCloneClient.swift
@@ -1,0 +1,87 @@
+//
+//  TwitterCloneClient.swift
+//  NetworkKit
+//
+//  Created by Andrew Erickson on 2023-04-13.
+//  Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import os.log
+
+@MainActor
+open class TwitterCloneClient {
+
+    private let baseUrl: URL
+    private let encoder = TwitterCloneNetworkKit.jsonEncoder
+    private let decoder = TwitterCloneNetworkKit.jsonDecoder
+
+    public init(baseUrl baseUrlString: String) throws {
+        guard let baseUrl = URL(string: baseUrlString) else {
+            throw ClientError.urlInvalid
+        }
+        self.baseUrl = baseUrl
+    }
+
+    public func post<Request: Encodable, Response: Decodable>(route: Route, request: Request) async throws -> Response {
+        let requestData = try encoder.encode(request)
+        let request = createPostRequest(url: baseUrl.appending(path: route.path), httpBody: requestData)
+
+        let responseData = try await send(request)
+
+        return try decoder.decode(Response.self, from: responseData)
+    }
+
+    /// send a POST request without returning a response
+    public func post<Request: Encodable>(route: Route, request: Request) async throws {
+        let requestData = try encoder.encode(request)
+        let request = createPostRequest(url: baseUrl.appending(path: route.path), httpBody: requestData)
+
+        try await send(request)
+    }
+
+    private func createPostRequest(url: URL, httpBody: Data? = nil) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = httpBody
+
+        return request
+    }
+
+    @discardableResult
+    private func send(_ request: URLRequest) async throws -> Data {
+        let (responseData, response) = try await URLSession.shared.data(for: request)
+        if OSLog.networkPayloadLog.isEnabled(type: .debug) {
+            os_log(.debug, "Response: %{public}@", String(data: responseData, encoding: .utf8) ?? "")
+        }
+        let statusCode = (response as? HTTPURLResponse)?.statusCode
+
+        try TwitterCloneNetworkKit.checkStatusCode(statusCode: statusCode)
+
+        return responseData
+    }
+}
+
+public enum ClientError: Error {
+    case urlInvalid
+}
+
+public protocol Route {
+    var path: String { get }
+}
+
+public enum Routes: String, Route {
+    case auth
+    case signup = "auth/signup"
+    case changePassword = "auth/chpasswd"
+    case login = "auth/login"
+    case users = "auth/users"
+    case muxUpload = "auth/mux-upload"
+    case muxPlayback = "auth/mux-playback"
+    case muxAsset = "auth/mux-asset"
+
+    public var path: String {
+        rawValue
+    }
+}

--- a/TwitterClone/Targets/TimelineUI/Sources/Video/CameraViewController.swift
+++ b/TwitterClone/Targets/TimelineUI/Sources/Video/CameraViewController.swift
@@ -34,7 +34,7 @@ class CameraViewModel: ObservableObject, CameraViewControllerDelegate {
     func didFinishRecordingTo(outputFileURL: URL) {
         Task {
             do {
-                let uploadResponse = try await self.auth.muxUploadUrl()
+                let uploadResponse = try await self.auth.muxUpload()
                 if let uploadUrl = URL(string: uploadResponse.upload_url) {
                     
                     upload = MuxUpload(uploadURL: uploadUrl, videoFileURL: outputFileURL)


### PR DESCRIPTION
### What's changed

- After noticing a lot of repeating code for each of the requests in `TwitterCloneAuth` I thought it might be a good idea to consolidate that into a reusable method.

Before, many of the functions had the same pattern
```
var loginRequest = URLRequest(url: signupUrl)
loginRequest.httpMethod = "POST"
loginRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
loginRequest.httpBody = try TwitterCloneNetworkKit.jsonEncoder.encode(credential)

let (data, response) = try await URLSession.shared.data(for: loginRequest)
let statusCode = (response as? HTTPURLResponse)?.statusCode

if OSLog.networkPayloadLog.isEnabled(type: .debug) {
    os_log("signup response: %{public}@", log: OSLog.clientLog, type: .debug, String(data: data, encoding: .utf8) ?? "")
}

try TwitterCloneNetworkKit.checkStatusCode(statusCode: statusCode)

let authUser = try TwitterCloneNetworkKit.jsonDecoder.decode(AuthUser.self, from: data)
```

which has now been reduced to a single line
```
let authUser: AuthUser = try await post(route: Routes.signup, request: credential)
```

and all of the common networking logic has been moved into a new base class `TwitterCloneClient` in `NetworkKit`

#### Other Changes

- Added .DS_Store to gitignore
- Simplified `UserReference` to use default encoding (no functionality changes)
- Moved `persist()` function out of `AuthUser` in favour of a private function in `TwitterCloneAuth`. This helps simplify the `AuthUser` and decouple it from KeychainHelper.
- Changed `public func storedAuthUser() throws -> AuthUser {` to a computed `private var storedAuthUser: AuthUser? {` as its not necessary for this function to throw. The only place using it was calling `try? storeAuthUser()` which indicates that returning an optional AuthUser is likely what we want in this case.
- Added convenience methods to `KeychainHelper` so `requireUserpresence` didn't have to be provided in each call as well as passing in the enum case directly so `.rawValue` doesn't need to be called each time as well.
- Moved all the local URL variables in `TwitterCloneAuth` in favour of using `Route` and `Routes` definitions in `TwitterCloneClient`. This helps improve the readability and simplicity of the code in `TwitterCloneAuth`

### How to test

All of the endpoints should still work as they did before. Testing signup, login, and all other endpoints to verify no regressions.
