### PR TITLE
Reply Tweet Toolbar simplification

### DIFF
--- a/TwitterClone/Targets/TimelineUI/Sources/ReplyTweetView.swift
+++ b/TwitterClone/Targets/TimelineUI/Sources/ReplyTweetView.swift
@@ -93,78 +93,56 @@ public struct ReplyTweetView: View {
                         .disabled(isShowingComposeArea.isEmpty)
                     }
                     
-                    // Photo picker view
                     ToolbarItem(placement: .keyboard) {
-                        Button {
-                            print("tap to upload an image")
-                        } label: {
-                            VStack {
-                                PhotosPicker(
-                                    selection: $selectedItems,
-                                    maxSelectionCount: 1,
-                                    matching: .any(of: [.images, .not(.livePhotos)])
-                                ) {
-                                    Image(systemName: "photo.on.rectangle.angled")
-                                        .accessibilityLabel("Photo picker")
-                                        .accessibilityAddTraits(.isButton)
-                                }
-                                .onChange(of: selectedItems) { newItems in
-                                    selectedPhotosData.removeAll()
-                                    for newItem in newItems {
-                                        Task {
-                                            if let data = try? await newItem.loadTransferable(type: Data.self) {
-                                                selectedPhotosData.append(data)
-                                            }
+                        HStack {
+                            PhotosPicker(
+                                selection: $selectedItems,
+                                maxSelectionCount: 1,
+                                matching: .any(of: [.images, .not(.livePhotos)])
+                            ) {
+                                Image(systemName: "photo.on.rectangle.angled")
+                                    .accessibilityLabel("Photo picker")
+                                    .accessibilityAddTraits(.isButton)
+                            }
+                            .onChange(of: selectedItems) { newItems in
+                                selectedPhotosData.removeAll()
+                                for newItem in newItems {
+                                    Task {
+                                        if let data = try? await newItem.loadTransferable(type: Data.self) {
+                                            selectedPhotosData.append(data)
                                         }
                                     }
                                 }
                             }
-                        }
-                    }
-                    
-                    ToolbarItem(placement: .keyboard) {
-                        Button {
-                            print("tap to initiate a new Space")
-                        } label: {
-                            Image(systemName: "mic.badge.plus")
-                                .font(.subheadline)
-                                .fontWeight(.bold)
+
+                            Button {
+                                print("tap to initiate a new Space")
+                            } label: {
+                                Image(systemName: "mic.badge.plus")
+                                    .font(.subheadline)
+                                    .fontWeight(.bold)
+                            }
+                            Button {
+                                self.isRecording.toggle()
+                            } label: {
+                                Image(systemName: "waveform")
+                                    .font(.subheadline)
+                                    .fontWeight(.bold)
+                            }
+                            .fullScreenCover(isPresented: $isRecording) {
+                                RecordAudioView(profileInfoViewModel: profileInfoViewModel)
+                            }
+                            Button {
+                                print("tap to record audio")
+                            } label: {
+                                Image(systemName: "bolt.square")
+                                    .font(.subheadline)
+                                    .fontWeight(.bold)
+                            }
+
+                            Spacer()
                         }
                         
-                    }
-                    
-                    ToolbarItem(placement: .keyboard) {
-                        Button {
-                            self.isRecording.toggle()
-                        } label: {
-                            Image(systemName: "waveform")
-                                .font(.subheadline)
-                                .fontWeight(.bold)
-                        }
-                        .fullScreenCover(isPresented: $isRecording) {
-                            RecordAudioView(profileInfoViewModel: profileInfoViewModel)
-                        }
-                    }
-                    
-                    ToolbarItem(placement: .keyboard) {
-                        Button {
-                            print("tap to record audio")
-                        } label: {
-                            Image(systemName: "bolt.square")
-                                .font(.subheadline)
-                                .fontWeight(.bold)
-                        }
-                    }
-                    
-                    // For the sake of keeping the 4 above icons on the left of the keyboard
-                    ToolbarItem(placement: .keyboard) {
-                        Button {
-                            print("tap to record audio")
-                        } label: {
-                            Image(systemName: "")
-                                .font(.subheadline)
-                                .fontWeight(.bold)
-                        }
                     }
                 }
                 ForEach(selectedPhotosData, id: \.self) { photoData in

--- a/TwitterClone/Targets/TimelineUI/Sources/TweetAudioView.swift
+++ b/TwitterClone/Targets/TimelineUI/Sources/TweetAudioView.swift
@@ -77,45 +77,33 @@ public struct TweetAudioView: View {
                 }
                 
                 ToolbarItem(placement: .keyboard) {
-                    Button {
-                        print("tap to initiate a new Space")
-                    } label: {
-                        Image(systemName: "mic.badge.plus")
-                            .font(.subheadline)
-                            .fontWeight(.bold)
-                    }
-                    
-                }
-                
-                ToolbarItem(placement: .keyboard) {
-                    Button {
-                        //self.isRecording.toggle()
-                    } label: {
-                        Image(systemName: "waveform")
-                            .font(.subheadline)
-                            .fontWeight(.bold)
-                    }
-                    //.fullScreenCover(isPresented: $isRecording, content: RecordAudioView.init)
-                }
-                
-                ToolbarItem(placement: .keyboard) {
-                    Button {
-                        print("tap to record audio")
-                    } label: {
-                        Image(systemName: "bolt.square")
-                            .font(.subheadline)
-                            .fontWeight(.bold)
-                    }
-                }
-                
-                // For the sake of keeping the 4 above icons on the left of the keyboard
-                ToolbarItem(placement: .keyboard) {
-                    Button {
-                        print("tap to record audio")
-                    } label: {
-                        Image(systemName: "")
-                            .font(.subheadline)
-                            .fontWeight(.bold)
+                    HStack {
+                        Button {
+                            print("tap to initiate a new Space")
+                        } label: {
+                            Image(systemName: "mic.badge.plus")
+                                .font(.subheadline)
+                                .fontWeight(.bold)
+                        }
+
+                        Button {
+                            //self.isRecording.toggle()
+                        } label: {
+                            Image(systemName: "waveform")
+                                .font(.subheadline)
+                                .fontWeight(.bold)
+                        }
+                        //.fullScreenCover(isPresented: $isRecording, content: RecordAudioView.init)
+
+                        Button {
+                            print("tap to record audio")
+                        } label: {
+                            Image(systemName: "bolt.square")
+                                .font(.subheadline)
+                                .fontWeight(.bold)
+                        }
+
+                        Spacer()
                     }
                 }
             }


### PR DESCRIPTION
### What's changed
A log in the console `No symbol named '' found in system symbol set` originally drew my attention to why there was a missing image, which lead me to `ReplyTweetView`. This empty image seemed to be a workaround for alignment of icons in the toolbar above the keyboard.


<img width="405" alt="reply tweet keyboard toolbar" src="https://user-images.githubusercontent.com/1420670/231851772-15bd3e78-ecc8-4829-bc70-75426a56dd73.png">

This can be achieved without the empty image button by providing a single HStack to the ToolbarItem and adding a Spacer() on the right.

The one thing I'm not too sure about is that if multiple buttons are in the same TooblarItem, would that negatively affect accessibility?

#### Other changes
- The same change was applied to `TweetAudioView`
