### PR TITLE
MyProfile updates

### DIFF
--- a/TwitterClone/Targets/Feeds/Sources/FeedUser.swift
+++ b/TwitterClone/Targets/Feeds/Sources/FeedUser.swift
@@ -84,7 +84,7 @@ public struct FeedUser: Refable, Codable {
                         createdAt: Date(),
                         updatedAt: Date(),
                         aboutMe: "",
-                        profilePicture: nil
+                        profilePicture: "https://picsum.photos/id/64/200"
         )
     }
 

--- a/TwitterClone/Targets/Feeds/Sources/FeedsClient.swift
+++ b/TwitterClone/Targets/Feeds/Sources/FeedsClient.swift
@@ -108,7 +108,7 @@ public class FeedsClient: ObservableObject {
         return FeedsClient(authUser: authUser, urlString: region.rawValue)
     }
 
-    public static func previewClient() throws -> FeedsClient {
+    public static func previewClient() -> FeedsClient {
         return FeedsClient(authUser: AuthUser.previewUser(), urlString: Region.euWest.rawValue, mockEnabled: true)
     }
 

--- a/TwitterClone/Targets/HomeUI/Sources/HomeView.swift
+++ b/TwitterClone/Targets/HomeUI/Sources/HomeView.swift
@@ -96,9 +96,7 @@ public struct HomeView: View {
                         self.isShowingProfile.toggle()
                     })
                     .sheet(isPresented: $isShowingProfile, content: {
-                        MyProfile(contentView: { AnyView(MyProfileInfoAndTweets(feedsClient: feedsClient))
-                        })
-                        .environmentObject(feedsClient)
+                        MyProfileInfoAndTweets(feedsClient: feedsClient)
                     })
                 }
                 

--- a/TwitterClone/Targets/Profile/Sources/EditProfileView.swift
+++ b/TwitterClone/Targets/Profile/Sources/EditProfileView.swift
@@ -12,18 +12,13 @@ import Feeds
 
 public struct EditProfileView: View {
     @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject var feedsClient: FeedsClient
     @EnvironmentObject var profileInfoViewModel: ProfileInfoViewModel
     @StateObject var mediaPickerViewModel = MediaPickerViewModel()
     
-    @State var feedUser: FeedUser
-    
-    var feedsClient: FeedsClient
-    @State private var isEditingMyName = "Amos Gyamfi"
-    @State private var isEditingAboutMe = "#Developer #Advocate"
-    @State private var isEditingMyLocation = "Mount Olive DR, Toronto ON"
-    @State private var isEditingMyWebsite = "getstream.io"
-    public init (feedsClient: FeedsClient, currentUser: FeedUser) {
-        self.feedsClient = feedsClient
+    @State private var feedUser: FeedUser
+
+    public init (currentUser: FeedUser) {
         _feedUser = State(initialValue: currentUser)
     }
     
@@ -50,14 +45,14 @@ public struct EditProfileView: View {
                 
                 List {
                     HStack {
-                        Text("Firstname")
-                        TextField("firstname", text: $feedUser.firstname)
+                        Text("First Name")
+                        TextField("First Name", text: $feedUser.firstname)
                             .foregroundColor(.streamBlue)
                             .labelsHidden()
                     }
                     HStack {
-                        Text("Lastname")
-                        TextField("lastname", text: $feedUser.lastname)
+                        Text("Last Name")
+                        TextField("Last Name", text: $feedUser.lastname)
                             .foregroundColor(.streamBlue)
                             .labelsHidden()
                     }

--- a/TwitterClone/Targets/Profile/Sources/ProfileFollower.swift
+++ b/TwitterClone/Targets/Profile/Sources/ProfileFollower.swift
@@ -1,5 +1,5 @@
 //
-//  MyProfile.swift
+//  ProfileFollower.swift
 //  TwitterClone
 //
 

--- a/TwitterClone/Targets/Profile/Sources/ProfileInfoView.swift
+++ b/TwitterClone/Targets/Profile/Sources/ProfileInfoView.swift
@@ -12,14 +12,50 @@ import Feeds
 import TwitterCloneUI
 
 public class ProfileInfoViewModel: ObservableObject {
-    @Published public var feedUser: FeedUser?
-    
-    public init() {}
+
+    @Published
+    public var feedUser: FeedUser?
+
+    var fullname: String {
+        feedUser?.fullname ?? ""
+    }
+
+    var firstname: String {
+        feedUser?.firstname ?? ""
+    }
+
+    var lastname: String {
+        feedUser?.lastname ?? ""
+    }
+
+    var username: String {
+        feedUser?.username ?? ""
+    }
+
+    var aboutMe: String {
+        feedUser?.aboutMe ?? ""
+    }
+
+    var location: String {
+        feedUser?.location ?? ""
+    }
+
+    var joinedDateString: String {
+        formattedDate(date: feedUser?.createdAt)
+    }
+
+    public var profilePictureUrlString: String? {
+        feedUser?.profilePicture
+    }
+
+    public init(feedUser: FeedUser? = nil) {
+        self.feedUser = feedUser
+    }
     
     let following = 10
     let followers = 11
     
-    func formattedDate(date: Date?) -> String {
+    private func formattedDate(date: Date?) -> String {
         guard let date else {
             return "-"
         }
@@ -38,25 +74,25 @@ public struct ProfileInfoView: View {
         
     public var body: some View {
         VStack(alignment: .leading) {
-            Text(viewModel.feedUser?.fullname ?? "")
+            Text(viewModel.fullname)
                 .fontWeight(.bold)
-            Text(viewModel.feedUser?.username ?? "")
+            Text(viewModel.username)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
 
             VStack(alignment: .leading, spacing: 8) {
-                Text(viewModel.feedUser?.aboutMe ?? "")
+                Text(viewModel.aboutMe)
                     .font(.subheadline)
                 HStack(spacing: 16) {
                     HStack(spacing: 2) {
                         Image(systemName: "mappin.and.ellipse")
-                        Text(viewModel.feedUser?.location ?? "")
+                        Text(viewModel.location)
                     }
                     .font(.caption)
 
                     HStack(spacing: 2) {
                         Image(systemName: "calendar")
-                        Text("Joined \(viewModel.formattedDate(date: viewModel.feedUser?.createdAt))")
+                        Text("Joined \(viewModel.joinedDateString)")
                     }
                     .font(.caption)
                 }
@@ -85,9 +121,11 @@ public struct ProfileInfoView: View {
     }
 }
 
-// struct ProfileInfoView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        ProfileInfoView(myProfile: MyProfileData)
-//            .preferredColorScheme(.dark)
-//    }
-// }
+struct ProfileInfoView_Previews: PreviewProvider {
+    static let feedUser = FeedUser.previewUser()
+
+    static var previews: some View {
+        ProfileInfoView(viewModel: ProfileInfoViewModel(feedUser: feedUser))
+            .preferredColorScheme(.dark)
+    }
+}

--- a/TwitterClone/Targets/Profile/Sources/ProfileSummaryView.swift
+++ b/TwitterClone/Targets/Profile/Sources/ProfileSummaryView.swift
@@ -13,25 +13,20 @@ import Feeds
 public struct ProfileSummaryView: View {
     @EnvironmentObject var profileInfoViewModel: ProfileInfoViewModel
 
-    @State private var isEditingPresented = false
-    
-    private var contentView: (() -> AnyView)
-    public init (contentView: @escaping (() -> AnyView)) {
-        self.contentView = contentView
-    }
+    public init () {}
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             List {
                 // Link to the full profile page: MyProfile.swift
                 NavigationLink {
-                    MyProfile(contentView: contentView)
+                    MyProfile()
                 } label: {
                     Image(systemName: "person.circle.fill")
                     Text("View full profile")
                 }
 
-                // Link to the full profile page: MyProfile.swift
+                // Link to the settings page
                 NavigationLink {
                     SettingsView()
                 } label: {

--- a/TwitterClone/Targets/Profile/Sources/ProfileUnfollower.swift
+++ b/TwitterClone/Targets/Profile/Sources/ProfileUnfollower.swift
@@ -1,5 +1,5 @@
 //
-//  MyProfile.swift
+//  ProfileUnfollower.swift
 //  TwitterClone
 //
 

--- a/TwitterClone/Targets/Profile/Sources/SettingsView.swift
+++ b/TwitterClone/Targets/Profile/Sources/SettingsView.swift
@@ -20,81 +20,28 @@ public struct SettingsView: View {
     @EnvironmentObject var auth: TwitterCloneAuth
     @EnvironmentObject var chatModel: ChatModel
     @EnvironmentObject var purchaseViewModel: PurchaseViewModel
+    @EnvironmentObject var profileInfoViewModel: ProfileInfoViewModel
     @Environment(\.presentationMode) var presentationMode
     
     @StateObject var mediaPickerViewModel = MediaPickerViewModel()
     
-    @State private var isEditingName = "Amos Gyamfi"
+    @State private var currentFirstName: String = ""
+    @State private var currentLastName: String = ""
+    @State private var currentUsername: String = ""
     @State private var isEditingUserName = false
     @State private var isEditingPassword = false
-    @State private var isLoggedOut = false
+
     public init () {}
     
     public var body: some View {
         NavigationStack {
             List {
-                HStack {
-                    Button {
-                        print("Open the photo picker")
-                    } label: {
-                        HStack {
-                            ZStack {
-                                ProfileImage(imageUrl: "https://picsum.photos/id/64/200", action: {})
-                                    .opacity(0.6)
-                                MediaPickerView(viewModel: mediaPickerViewModel)
-                            }
-                            Image(systemName: "pencil")
-                                .fontWeight(.bold)
-                        }
-                    }
-                    
-                    Spacer()
-                }
-                
-                HStack {
-                    Text("Change your Name")
-                    TextField("Amos Gyamfi", text: $isEditingName)
-                        .foregroundColor(.streamBlue)
-                        .labelsHidden()
-                }
-                
-                NavigationLink {
-                    EditUserName()
-                } label: {
-                    Button {
-                        self.isEditingUserName.toggle()
-                    } label: {
-                        HStack {
-                            Text("Change your username")
-                            Spacer()
-                            Text("@stefanjblos")
-                        }
-                    }
-                }
-                
-                NavigationLink {
-                    EditPassword(auth: auth)
-                } label: {
-                    Button {
-                        self.isEditingPassword.toggle()
-                    } label: {
-                        HStack {
-                            Text("Change your password")
-                            Spacer()
-                        }
-                    }
-                }
-
-                if purchaseViewModel.isSubscriptionActive {
-                    Text("You are subscribed")
-                        .padding(.top)
-                } else {
-                    if let packages = purchaseViewModel.offerings?.current?.availablePackages {
-                        ForEach(packages) { package in
-                            SubscribeBlue(package: package)
-                        }
-                    }
-                }
+                profilePhotoRow
+                firstNameRow
+                lastNameRow
+                usernameRow
+                passwordRow
+                subscriptionRow
             }
             .listStyle(.plain)
             .navigationTitle("")
@@ -117,11 +64,108 @@ public struct SettingsView: View {
             
             Spacer()
         }
+        .task {
+            currentFirstName = profileInfoViewModel.firstname
+            currentLastName = profileInfoViewModel.lastname
+        }
+    }
+
+    var profilePhotoRow: some View {
+        HStack {
+            Button {
+                print("Open the photo picker")
+            } label: {
+                HStack {
+                    ZStack {
+                        ProfileImage(imageUrl: profileInfoViewModel.profilePictureUrlString, action: {})
+                            .opacity(0.6)
+                        MediaPickerView(viewModel: mediaPickerViewModel)
+                    }
+                    Image(systemName: "pencil")
+                        .fontWeight(.bold)
+                }
+            }
+
+            Spacer()
+        }
+    }
+
+    var firstNameRow: some View {
+        HStack {
+            Text("Change your first name")
+            Spacer()
+            TextField("Enter a first name", text: $currentFirstName)
+                .foregroundColor(.streamBlue)
+                .labelsHidden()
+        }
+    }
+
+    var lastNameRow: some View {
+        HStack {
+            Text("Change your last name")
+            Spacer()
+            TextField("Enter a last name", text: $currentLastName)
+                .foregroundColor(.streamBlue)
+                .labelsHidden()
+        }
+    }
+
+    var usernameRow: some View {
+        NavigationLink {
+            EditUserName()
+        } label: {
+            Button {
+                self.isEditingUserName.toggle()
+            } label: {
+                HStack {
+                    Text("Change your username")
+                    Spacer()
+                    Text(currentUsername)
+                }
+            }
+        }
+    }
+
+    var passwordRow: some View {
+        NavigationLink {
+            EditPassword(auth: auth)
+        } label: {
+            Button {
+                self.isEditingPassword.toggle()
+            } label: {
+                HStack {
+                    Text("Change your password")
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    var subscriptionRow: some View {
+        if purchaseViewModel.isSubscriptionActive {
+            Text("You are subscribed")
+                .padding(.top)
+        } else {
+            if let packages = purchaseViewModel.offerings?.current?.availablePackages {
+                ForEach(packages) { package in
+                    SubscribeBlue(package: package)
+                }
+            }
+        }
     }
 }
 
-//struct SettingsView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        SettingsView()
-//    }
-//}
+struct SettingsView_Previews: PreviewProvider {
+    static let profileInfoViewModel = ProfileInfoViewModel(feedUser: FeedUser.previewUser())
+    // swiftlint:disable:next force_try
+    static let auth = try! TwitterCloneAuth(baseUrl: "http://localhost:8080")
+    static let purchaseViewModel = PurchaseViewModel()
+
+    static var previews: some View {
+        SettingsView()
+            .environmentObject(profileInfoViewModel)
+            .environmentObject(auth)
+            .environmentObject(purchaseViewModel)
+    }
+}

--- a/TwitterClone/Targets/TimelineUI/Sources/AddNewTweetView.swift
+++ b/TwitterClone/Targets/TimelineUI/Sources/AddNewTweetView.swift
@@ -46,7 +46,7 @@ public struct AddNewTweetView: View {
             VStack {
                 HStack(alignment: .top) {
                     
-                    ProfileImage(imageUrl: profileInfoViewModel.feedUser?.profilePicture, action: {})
+                    ProfileImage(imageUrl: profileInfoViewModel.profilePictureUrlString, action: {})
                     TextField("What's happening?", text: $isShowingComposeArea, axis: .vertical)
                         .textFieldStyle(.roundedBorder)
                         .lineLimit(3, reservesSpace: true)

--- a/TwitterClone/Targets/TimelineUI/Sources/MyProfileInfoAndTweets.swift
+++ b/TwitterClone/Targets/TimelineUI/Sources/MyProfileInfoAndTweets.swift
@@ -10,11 +10,8 @@ import Auth
 import Profile
 
 public struct MyProfileInfoAndTweets: View {
-    private var feedsClient: FeedsClient
-    
-    @State private var isShowingEditProfile = false
-    
     @EnvironmentObject var profileInfoViewModel: ProfileInfoViewModel
+    private var feedsClient: FeedsClient
 
     @State private var selection = 0
 
@@ -23,42 +20,20 @@ public struct MyProfileInfoAndTweets: View {
     }
     
     public var body: some View {
-        ScrollView {
-            VStack(alignment: .leading) {
-                HStack {
-                    ProfileImage(imageUrl: profileInfoViewModel.feedUser?.profilePicture, action: {})
-                            .scaleEffect(1.2)
-
-                    Spacer()
-
-                    Button {
-                        isShowingEditProfile.toggle()
-                        print("Navigate to edit profile page")
-                    } label: {
-                        Text("Edit profile")
-                            .font(.subheadline)
-                            .fontWeight(.bold)
-                    }
-                    .sheet(isPresented: $isShowingEditProfile, content: {
-                        if let feedUser = profileInfoViewModel.feedUser {
-                            EditProfileView(feedsClient: feedsClient, currentUser: feedUser)
-                        }
-                    })
-                    .buttonStyle(.borderedProminent)
-                }
-
-                ProfileInfoView(viewModel: profileInfoViewModel)
-
-                ForYouFeedsView(feedType: .user(userId: feedsClient.authUser.userId))
-                    .frame(height: UIScreen.main.bounds.height)
-            }.padding()
-        }
+        MyProfile(footerContent: {
+             ForYouFeedsView(feedType: .user(userId: feedsClient.authUser.userId))
+                .frame(height: UIScreen.main.bounds.height)
+        })
     }
 }
 
-// struct MyProfileInfoAndTweets_Previews: PreviewProvider {
-//    static var previews: some View {
-//        MyProfileInfoAndTweets()
-//            .preferredColorScheme(.dark)
-//    }
-// }
+struct MyProfileInfoAndTweets_Previews: PreviewProvider {
+    static let feedsClient = FeedsClient.previewClient()
+    static let feedUser = FeedUser.previewUser()
+
+    static var previews: some View {
+        MyProfileInfoAndTweets(feedsClient: feedsClient)
+            .environmentObject(ProfileInfoViewModel(feedUser: feedUser))
+            .preferredColorScheme(.dark)
+    }
+}

--- a/TwitterClone/Targets/TimelineUI/Sources/ProfileInfoAndTweets.swift
+++ b/TwitterClone/Targets/TimelineUI/Sources/ProfileInfoAndTweets.swift
@@ -14,7 +14,6 @@ struct ProfileInfoAndTweets: View {
     var profilePicture: String?
     
     @EnvironmentObject var feedsClient: FeedsClient
-    @State private var selection = 0
     
     @StateObject var profileInfoViewModel = ProfileInfoViewModel()
 

--- a/TwitterClone/Targets/TimelineUI/Sources/RecordAudioView.swift
+++ b/TwitterClone/Targets/TimelineUI/Sources/RecordAudioView.swift
@@ -25,7 +25,7 @@ public struct RecordAudioView: View {
             VStack {
                 Spacer()
         
-                ProfileImage(imageUrl: profileInfoViewModel.feedUser?.profilePicture, action: {})
+                ProfileImage(imageUrl: profileInfoViewModel.profilePictureUrlString, action: {})
                     .overlay(Circle().stroke(lineWidth: 2))
                     .scaleEffect(2)
                 

--- a/TwitterClone/Targets/TimelineUI/Sources/ReplyTweetView.swift
+++ b/TwitterClone/Targets/TimelineUI/Sources/ReplyTweetView.swift
@@ -64,7 +64,7 @@ public struct ReplyTweetView: View {
                 
                 HStack(alignment: .top) {
                     
-                    ProfileImage(imageUrl: profileInfoViewModel.feedUser?.profilePicture, action: {})
+                    ProfileImage(imageUrl: profileInfoViewModel.profilePictureUrlString, action: {})
                     TextField("Tweet your reply", text: $isShowingComposeArea, axis: .vertical)
                         .textFieldStyle(.roundedBorder)
                         .lineLimit(3, reservesSpace: true)
@@ -163,8 +163,10 @@ public struct ReplyTweetView: View {
 }
 
 struct ReplyTweetView_Previews: PreviewProvider {
+    static let feedUser = FeedUser.previewUser()
+
     static var previews: some View {
-        ReplyTweetView(profileInfoViewModel: ProfileInfoViewModel(), parentActivityId: "")
+        ReplyTweetView(profileInfoViewModel: ProfileInfoViewModel(feedUser: feedUser), parentActivityId: "")
             .preferredColorScheme(.dark)
     }
 }


### PR DESCRIPTION
### What's changed
The main change in this PR is in MyProfile. Previously it was requiring a `contentView` to be passed in which would contain the bulk of the profile UI, which was mostly defined in `MyProfileInfoAndTweets`. After seeing if I could swap the two, it became apparent why it may have been done this way since MyProfileInfoAndTweets relies on feed information and lives in the `TimelineUI` micro framework. Trying to simply move MyProfileInfoAndTweets into the Profile framework would not work because it would create a circular dependency.

What I was able to do instead was extract the bulk of the profile UI back into MyProfile and then optionally provide additional content that would still exist in the scrollview on my profile. That way `MyProfileInfoAndTweets` can call MyProfile and provide the `ForYouFeedsView` as its footer content as intended.

<img width="405" alt="Screenshot 2023-04-14 at 2 49 18 PM" src="https://user-images.githubusercontent.com/1420670/232151940-eeb49cad-ef93-4c85-b743-8cebc8331b98.png">

#### Other changes
- Updated `EditProfileView` removing unused variables and some minor label changes.
- Enabled previews in any of the views that made sense (I hope that's ok!) Although previews don't have the best reputation, and can be tricky to enable when using environment variables I think they are a super valuable way to ensure you're writing modular code.
- Minor naming updates 
- Created convenience computed variables in `ProfileInfoViewModel` that help making the code in the view easier to read
- Updated `SettingsView` to initially populate with the current logged in user, as well as extracted out each row/view for readability


### How to test
- After logging in, tap on the profile image in the top left as before to see the MyProfile view. It should load with basic profile information as well as any of the current user's tweets (as it did before)
- Tapping the settings gear icon should show the updates to the Settings page
> <img width="376" alt="Screenshot 2023-04-14 at 2 47 08 PM" src="https://user-images.githubusercontent.com/1420670/232151619-53350a86-9f6e-4a87-9ab6-97dd10c09210.png">

- Navigating back to the profile and then into "Edit Profile" should load and display as it did before.

> <img width="381" alt="Screenshot 2023-04-14 at 2 48 08 PM" src="https://user-images.githubusercontent.com/1420670/232151767-4e3ec821-706f-4611-bb1e-48e201305049.png">
