### PR TITLE
Fix Swiftlint Warnings

### DIFF
--- a/TwitterClone/Targets/Auth/Sources/TwitterCloneAuth.swift
+++ b/TwitterClone/Targets/Auth/Sources/TwitterCloneAuth.swift
@@ -165,7 +165,7 @@ public final class TwitterCloneAuth: TwitterCloneClient, ObservableObject {
     
     public func muxUpload() async throws -> MuxUploadResponse {
         // TODO: provide request data
-        let response: MuxUploadResponse = try await post(route: Routes.muxUpload, request: ["":""])
+        let response: MuxUploadResponse = try await post(route: Routes.muxUpload, request: ["": ""])
         return response
     }
     

--- a/TwitterClone/Targets/Profile/Sources/SubscribeBlue.swift
+++ b/TwitterClone/Targets/Profile/Sources/SubscribeBlue.swift
@@ -73,7 +73,7 @@ public struct SubscribeBlue: View {
                     }
                 }
                 Button {
-                    Purchases.shared.purchase(package: package) { transaction, customerInfo, error, userCancelled in
+                    Purchases.shared.purchase(package: package) { _, customerInfo, _, _ in
                         if customerInfo?.entitlements.all["blue"]?.isActive == true {
                             print("Bought")
                         }

--- a/TwitterClone/Targets/Spaces/Sources/ViewModel/SpacesViewModel+Channel.swift
+++ b/TwitterClone/Targets/Spaces/Sources/ViewModel/SpacesViewModel+Channel.swift
@@ -37,8 +37,8 @@ extension SpacesViewModel {
 extension SpacesViewModel: EventsControllerDelegate {
     
     public func eventsController(_ controller: EventsController, didReceiveEvent event: Event) {
-        /// We should be more fine-grained when listening to events here. This is more like a brute-force method.
-        /// Examples can be found with the `ChannelEvent` and `MemberEvent` in StreamChat.
+        // We should be more fine-grained when listening to events here. This is more like a brute-force method.
+        // Examples can be found with the `ChannelEvent` and `MemberEvent` in StreamChat.
         guard let event = event as? ChannelUpdatedEvent else { return }
         let updatedSpace = Space.from(event.channel)
         

--- a/TwitterClone/Targets/Spaces/Sources/ViewModel/SpacesViewModel+CreateSpace.swift
+++ b/TwitterClone/Targets/Spaces/Sources/ViewModel/SpacesViewModel+CreateSpace.swift
@@ -38,7 +38,7 @@ extension SpacesViewModel {
             return
         }
         
-        /// We should probably do more proper error handling here. At least we're showing the error, which is a start.
+        // We should probably do more proper error handling here. At least we're showing the error, which is a start.
         channelController.synchronize { [weak self] error in
             if let error {
                 self?.setInfoMessage(text: "Synchronize error: \(error.localizedDescription)", type: .error)

--- a/TwitterClone/Targets/Spaces/Sources/ViewModel/SpacesViewModel+HMSUpdateListener.swift
+++ b/TwitterClone/Targets/Spaces/Sources/ViewModel/SpacesViewModel+HMSUpdateListener.swift
@@ -22,15 +22,15 @@ extension SpacesViewModel: HMSUpdateListener {
     public func on(removedFromRoom notification: HMSRemovedFromRoomNotification) {
         print("[HMSUpdate] onRemovedFromRoom: \(notification.description), reason: \(notification.reason)")
         
-        /// This will be called if the host has ended the room. In this case, we need to clean up and end the space locally.
-        /// Cleanup the tracks
+        // This will be called if the host has ended the room. In this case, we need to clean up and end the space locally.
+        // Cleanup the tracks
         ownTrack = nil
         otherTracks = []
         
-        /// In the end we update the state.
+        // In the end we update the state.
         isInSpace = false
         
-        /// Show the information that the room has ended, and why, to the user.
+        // Show the information that the room has ended, and why, to the user.
         setInfoMessage(text: "You were removed from the space.\n\(notification.reason)", type: .information)
     }
     
@@ -39,9 +39,9 @@ extension SpacesViewModel: HMSUpdateListener {
         print("[HMSUpdate] on peer: \(peer.name), update: \(update.description)")
         switch update {
         case .peerJoined:
-            /// When we are host and it's not the local peer
+            // When we are host and it's not the local peer
             if isHost && !peer.isLocal {
-                /// Change the role of the peer to "listener"
+                // Change the role of the peer to "listener"
                 if let listenerRole = hmsSDK.roles.first(where: { role in
                     role.name == "listener"
                 }) {
@@ -57,7 +57,7 @@ extension SpacesViewModel: HMSUpdateListener {
         print("[HMSUpdate] on track: \(track.trackId), update: \(update.description), peer: \(peer.name)")
         switch update {
         case .trackAdded:
-            /// If the track that was added is an audio track, add it to our tracks.
+            // If the track that was added is an audio track, add it to our tracks.
             if let audioTrack = track as? HMSAudioTrack {
                 if peer.isLocal {
                     ownTrack = audioTrack
@@ -66,7 +66,7 @@ extension SpacesViewModel: HMSUpdateListener {
                 }
             }
         case .trackRemoved:
-            /// If the track that was removed is an audio track, remove it from our tracks.
+            // If the track that was removed is an audio track, remove it from our tracks.
             if let audioTrack = track as? HMSAudioTrack {
                 if peer.isLocal {
                     ownTrack = nil
@@ -99,9 +99,7 @@ extension SpacesViewModel: HMSUpdateListener {
         // Someone is speaking
         // This can be used to indicate who is speaking and visually show this
         withAnimation {
-            speakerIds = Set(speakers
-                             /// The metadata is equal to the userId
-                .compactMap { $0.peer.metadata })
+            speakerIds = Set(speakers.compactMap { $0.peer.metadata }) // The metadata is equal to the userId
         }
     }
     


### PR DESCRIPTION
### What's changed
No functional changes. Not sure how important this is but as I'm exploring this example app the SwiftLint warnings are a little distracting after building the project, especially as I start to modify code and play around.

- Replaced any `///` with `//` when it was a code level comment and not documentation
- Fixed cyclomatic complexity by moving grouped functionality into private functions.
- Moved `NotificationCenter.default.removeObserver(self)` into `deinit` in `CameraViewController` instead of calling it as part of viewWillDisappear based on the warning's suggestion.
- A few other minor formatting fixes